### PR TITLE
Enable Python basic slicing when using cat to look into datasets.

### DIFF
--- a/h5nav/cli.py
+++ b/h5nav/cli.py
@@ -309,7 +309,7 @@ class H5NavCmd(ExitCmd, ShellCmd, SmartCmd, cmd.Cmd, object):
         print("Enter group. Also ok: `cd ..` (up), `cd -` (last), `cd` (root)")
 
     def top_level_spaces(self, s):
-        """Count top-level spaces in `s`, ignoring those within square brackets"""
+        """Count top-level spaces in s, ignoring those within square brackets"""
         balance = 0
         count = 0
         for c in s:
@@ -536,7 +536,7 @@ class H5NavCmd(ExitCmd, ShellCmd, SmartCmd, cmd.Cmd, object):
         return slice(*[int(p) if p else None for p in parts])
 
     def get_elem_slice(self, name, slice_string):
-        """Print slice of dataset or group using name"""
+        """Get the slice_string slice of a dataset or group using name"""
         dim_strings = [x.strip() for x in slice_string.split(',')]
         s_slice = ()
         for dim in dim_strings:


### PR DESCRIPTION
Support slicing with the basic Python syntax start:stop:step for multi-dimensional datasets.

Rundown of the changes:
- New function top_level_spaces: spaces may be included in the slicing syntax, so we need to count the top-level spaces only, ignoring those within square brackets. We could use a regex expression instead, but that requires importing the re module.
- Slicing is recognized by the presence of a '[' character in the cat argument. No sane person would use square brackets to name their datasets, right?
- New function get_elem_slice: returns the slice we want. Calls parse_slice (cf below).
- New function parse_slice: reads a string in the start:stop:step format and returns the corresponding slice object.